### PR TITLE
Correction of case where char equals 0 or 9

### DIFF
--- a/AC1/A4 - Manipulação de arrays e Strings/e1a.asm
+++ b/AC1/A4 - Manipulação de arrays e Strings/e1a.asm
@@ -42,8 +42,8 @@ while:
 	
 	# check if it is a number
 if:	
-	ble char, 0x2f, endif
-	bge char, 0x3a, endif
+	blt char, 0x2f, endif
+	bgt char, 0x3a, endif
 	addi num, num, 1
 	
 endif:


### PR DESCRIPTION
The instructions 'ble' and 'bge' did not cover the case where char = 0 or char = 9, since it's trying to check the condition '0 <= char && char <= 9'